### PR TITLE
add a new `serviceName` to the engine statefulset spec and configmap with new parameters

### DIFF
--- a/charts/node/templates/engine-cm.yaml
+++ b/charts/node/templates/engine-cm.yaml
@@ -21,15 +21,13 @@ data:
     [eth]
     # Ethereum private key file path. Default is the docker secrets path. This file should contain a hex-encoded private key.
     private_key_file = "{{ .Values.common.keys.keysPath }}/{{ .Values.common.keys.ethereumKeyFileName }}"
-
-    [eth.rpc]
-    ws_endpoint = "{{ required "Please provide a ws_endpoint of an Ethereum node" .Values.engine.settings.eth.ws_endpoint }}"
-    http_endpoint = "{{ required "Please provide a http_endpoint of an Ethereum node" .Values.engine.settings.eth.http_endpoint }}"
+    ws_node_endpoint = "{{ required "Please provide a ws_node_endpoint of an Ethereum node" .Values.engine.settings.eth.ws_node_endpoint }}"
+    http_node_endpoint = "{{ required "Please provide a http_node_endpoint of an Ethereum node" .Values.engine.settings.eth.http_node_endpoint }}"
 
     {{ if .Values.engine.settings.eth_backup.enabled }}
     [eth.backup_rpc]
-    http_endpoint = "{{ .Values.engine.settings.eth_backup.http_endpoint }}"
-    ws_endpoint = "{{ .Values.engine.settings.eth_backup.ws_endpoint }}"
+    http_node_endpoint = "{{ .Values.engine.settings.eth_backup.http_node_endpoint }}"
+    ws_node_endpoint = "{{ .Values.engine.settings.eth_backup.ws_node_endpoint }}"
     {{- end }}
 
     {{ if .Values.engine.ports.healthcheck.enabled }}
@@ -41,24 +39,24 @@ data:
     [signing]
     db_file = "{{ .Values.common.basePath }}/data.db"
 
-    [dot.rpc]
-    ws_endpoint = "{{ required "Please provide a ws_endpoint of an Polkadot node" .Values.engine.settings.dot.ws_endpoint }}"
-    http_endpoint = "{{ required "Please provide a http_endpoint of an Polkadot node" .Values.engine.settings.dot.http_endpoint }}"
+    [dot]
+    ws_node_endpoint = "{{ required "Please provide a ws_node_endpoint of an Polkadot node" .Values.engine.settings.dot.ws_node_endpoint }}"
+    http_node_endpoint = "{{ required "Please provide a http_node_endpoint of an Polkadot node" .Values.engine.settings.dot.http_node_endpoint }}"
 
     {{ if .Values.engine.settings.dot_backup.enabled }}
     [dot.backup_rpc]
-    http_endpoint = "{{ .Values.engine.settings.dot_backup.http_endpoint }}"
-    ws_endpoint = "{{ .Values.engine.settings.dot_backup.ws_endpoint }}"
+    http_node_endpoint = "{{ .Values.engine.settings.dot_backup.http_node_endpoint }}"
+    ws_node_endpoint = "{{ .Values.engine.settings.dot_backup.ws_node_endpoint }}"
     {{- end }}
 
-    [btc.rpc]
-    http_endpoint = "{{ required "Please provide a http_endpoint of an Bitcoin node" .Values.engine.settings.btc.http_endpoint }}"
-    basic_auth_user = "{{ .Values.engine.settings.btc.basic_auth_user }}"
-    basic_auth_password = "{{ .Values.engine.settings.btc.basic_auth_password }}"
+    [btc]
+    http_node_endpoint = "{{ required "Please provide a http_node_endpoint of an Bitcoin node" .Values.engine.settings.btc.http_node_endpoint }}"
+    rpc_user = "{{ .Values.engine.settings.btc.basic_auth_user }}"
+    rpc_password = "{{ .Values.engine.settings.btc.basic_auth_password }}"
 
     {{ if .Values.engine.settings.btc_backup.enabled }}
     [btc.backup_rpc]
-    http_endpoint = "{{ .Values.engine.settings.btc_backup.http_endpoint }}"
+    http_node_endpoint = "{{ .Values.engine.settings.btc_backup.http_node_endpoint }}"
     rpc_user = "{{ .Values.engine.settings.btc_backup.rpc_user }}"
     rpc_password = "{{ .Values.engine.settings.btc_backup.rpc_password }}"
     {{- end }}

--- a/charts/node/templates/engine-statefulset.yaml
+++ b/charts/node/templates/engine-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "chainflip-engine.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "chainflip-engine.fullname" . }}
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
Add a new `serviceName` field to the engine statefulset spec in order to resolve the issue described below
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec`

