### PR TITLE
chore: use fullname for selector label

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 
 type: application
 
-version: 0.18.5
+version: 0.19.0
 
 appVersion: "1.10.0"

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -59,7 +59,7 @@ Selector labels
 */}}
 {{- define "chainflip-node.selectorLabels" -}}
 chainflip.io/unit: chainflip-node
-chainflip.io/name: {{ .Release.Name }}
+chainflip.io/name: {{ include "node.fullname" . }}
 {{- end }}
 
 {{/*
@@ -111,7 +111,7 @@ Common labels
 Selector labels
 */}}
 {{- define "chainflip-engine.selectorLabels" -}}
-chainflip.io/name: {{ .Release.Name }}
+chainflip.io/name: {{ include "node.fullname" . }}
 chainflip.io/unit: chainflip-engine
 {{- end }}
 


### PR DESCRIPTION
* This allows for multiple node deployments (like in brokers and LPs) to be selected individually, as aliases are included.